### PR TITLE
Corrected typo preventing from seeing the two RLE outputs.

### DIFF
--- a/source/transformify/main.cpp
+++ b/source/transformify/main.cpp
@@ -157,7 +157,7 @@ static int transformify_main(int argc, char* argv[])
             rawValuesOutputBuffer.shrink_to_fit();
 
             // Write the lengths bytestream
-            std::string lengthsOutputFilePath = programOptions.inputFilePath + ".rle_coding.raw_values";
+            std::string lengthsOutputFilePath = programOptions.inputFilePath + ".rle_coding.length_values";
             transformify::OutputFile lengthsOutputFile(lengthsOutputFilePath);
             lengthsOutputFile.write(&lengthsOutputBuffer[0], 1, lengthsOutputBuffer.size());
             TRANSFORMIFY_LOG_INFO << "Wrote lengths bytestream of size " << lengthsOutputBuffer.size() << " to: " << lengthsOutputFilePath;


### PR DESCRIPTION
### Description of the Change
In the output of transformify, the main overwrote the result of raw values with length: the length data was using the same file name as the raw values.

### Benefits
All data is now correctly outputed.

### Possible Drawbacks
More output weight, but now it is the correct weight, not the weight resulting from loosing the info.

### Applicable Issues
Do not know any other related issues.