### PR TITLE
An underflow meant that for first windowsSize values, no search was d…

### DIFF
--- a/source/gabac/match_coding.cpp
+++ b/source/gabac/match_coding.cpp
@@ -192,7 +192,7 @@ void transformMatchCoding(
     {
         uint64_t pointer = 0;
         uint64_t length = 0;
-        uint64_t windowStartIdx = i - windowSize;
+        uint64_t windowStartIdx = i > windowSize ? i - windowSize : 0;
         uint64_t windowEndIdx = i;
 
         for (uint64_t w = windowStartIdx; w < windowEndIdx; w++)

--- a/source/transformify/output_file.cpp
+++ b/source/transformify/output_file.cpp
@@ -11,7 +11,6 @@ namespace transformify {
 
 OutputFile::OutputFile(const std::string& path) : File(path, "wb")
 {
-    open(path, "wb");
 }
 
 


### PR DESCRIPTION
### Description of the Change

The algorithm for match coding works on a window prior to the current position. In order to calculate the position where the window starts, the size is substracted from the current position. Due to the language (C++) and the variable type (unsigned) this means that there is an underflow, leading to negative numbers interpreted as very big numbers. As the for loop stops at the current position, this could not produce segmentation faults.
The change makes sure that no underflow will occur, otherwise the window start is set to 0.

### Benefits

This change ensures that it is possible to find matches for the positions having an index smaller than window size.

### Possible Drawbacks

This modification will very slightly increase the computation time.

### Applicable Issues

This does not solve a bug, nor any issue, it only ensures that a little bit more compression through encoding can be gained.
